### PR TITLE
Add support for multiple js files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,11 @@ COPY ./dev/nginx.conf /etc/nginx/nginx.conf
 
 COPY --from=build  /usr/angular-workdir/dist/angular-docker /usr/share/nginx/html
 
-RUN echo "mainFileName=\"\$(ls /usr/share/nginx/html/main*.js)\" && \
-          envsubst '\$BACKEND_API_URL \$DEFAULT_LANGUAGE ' < \${mainFileName} > main.tmp && \
-          mv main.tmp \${mainFileName} && nginx -g 'daemon off;'" > run.sh
+RUN echo "for mainFileName in /usr/share/nginx/html/main*.js ;\
+            do \
+              envsubst '\$BACKEND_API_URL \$DEFAULT_LANGUAGE ' < \$mainFileName > main.tmp ;\
+              mv main.tmp \${mainFileName} ;\
+            done \
+            && nginx -g 'daemon off;'" > run.sh
 
 ENTRYPOINT ["sh", "run.sh"]


### PR DESCRIPTION
First of all thanks for the nicely written tutorial. I had only make some changes on the Dockerfile to get it work in our case using angular 8 (Don't know if this problem exists with other angular versions):

I found out that your code only works if
`ls /usr/share/nginx/html/main*.js`
delivers only one file. In our project we using angular 8 which compiles into two main*.js files (eg. main-es5.67214628493d680af0aa.js and main-es2015.6bf52531655f87b82bc4.js).
In our case the return of ls is interpreted as one file with name "main-es5.67214628493d680af0aa.js main-es2015.6bf52531655f87b82bc4.js" which is not found of course on container start up.

We are using now the solution in this PR. I hope this helps others with similar problems.